### PR TITLE
Update 'Gentium Plus' to 'Pankosmia-Gentium'

### DIFF
--- a/runtime_resources/pdf/bcv_bible_page_styles.css
+++ b/runtime_resources/pdf/bcv_bible_page_styles.css
@@ -21,7 +21,7 @@
 
 
 body {
-    font-family: "Gentium Plus", serif;
+    font-family: "Pankosmia-Gentium", serif;
     font-size: 12pt;
     line-height: 15pt;
 }
@@ -42,7 +42,7 @@ h1 {
     border-bottom: 0pt solid black;
     padding-bottom: 0pt;
     width: 479pt;
-    font-family: "Gentium Plus", serif;
+    font-family: "Pankosmia-Gentium", serif;
     break-after: avoid;
 }
 

--- a/templates/user_settings.json
+++ b/templates/user_settings.json
@@ -6,7 +6,7 @@
   "app_resources_dir": "%%APPRESOURCESDIR%%",
   "typography": {
     "direction": "ltr",
-    "font_set": "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus",
+    "font_set": "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-Gentium",
     "size": "medium",
     "features": {
       "Andika": [
@@ -51,11 +51,19 @@
           "value": 0
         },
         {
+          "key": "cv30",
+          "value": 0
+        },
+        {
           "key": "cv31",
           "value": 0
         },
         {
           "key": "cv35",
+          "value": 0
+        },
+        {
+          "key": "cv34",
           "value": 0
         },
         {
@@ -220,6 +228,10 @@
         },
         {
           "key": "cv07",
+          "value": 0
+        },
+        {
+          "key": "cv09",
           "value": 0
         }
       ],
@@ -391,7 +403,7 @@
           "value": 2
         }
       ],
-      "Charis_SIL": [
+      "Charis": [
         {
           "key": "smcp",
           "value": 0
@@ -545,6 +557,10 @@
           "value": 0
         },
         {
+          "key": "onum",
+          "value": 0
+        },
+        {
           "key": "subs",
           "value": 0
         },
@@ -557,7 +573,7 @@
           "value": 0
         }
       ],
-      "Gentium_Book_Plus": [
+      "Gentium_Book": [
         {
           "key": "smcp",
           "value": 0
@@ -727,6 +743,10 @@
           "value": 0
         },
         {
+          "key": "onum",
+          "value": 0
+        },
+        {
           "key": "subs",
           "value": 0
         },
@@ -739,7 +759,7 @@
           "value": 0
         }
       ],
-      "Gentium_Plus": [
+      "Gentium": [
         {
           "key": "smcp",
           "value": 0
@@ -906,6 +926,10 @@
         },
         {
           "key": "cv92",
+          "value": 0
+        },
+        {
+          "key": "onum",
           "value": 0
         },
         {


### PR DESCRIPTION
This is a coordinate PR, meant to be accepted in conjunction with:
- webfonts-core [PR 2](https://github.com/pankosmia/webfonts-core/pull/2)
- core-client-settings [PR 16](https://github.com/pankosmia/core-client-settings/pull/16)

The critical piece in this PR is the user_settings.json updates, including:
- Default font_set change from Pankosmia-GentiumPlus to Pankosmia-Gentium
- Font name changes in typography features
  - Charis SIL is now Charis
  - Gentium Plus is now Gentium
  - Gentium Book Plus is now Gentium Book
- Font Feature setting have been added:
  - 3 added to Andika
  - 1 added to Charis
  - 1 added to Gentium
  - 1 added to Gentium Book

**Gentium Plus is now Gentium
Pankosmia-Gentium is provided, and is set here to replacing local use of Gentium Plus**
