### PR TITLE
Avoid Padauk and Awami row collisions

### DIFF
--- a/runtime_resources/pdf/bcv_bible_page_styles.css
+++ b/runtime_resources/pdf/bcv_bible_page_styles.css
@@ -23,7 +23,6 @@
 body {
     font-family: "Pankosmia-Gentium", serif;
     font-size: 12pt;
-    line-height: 15pt;
 }
 
 
@@ -35,7 +34,6 @@ p {
 
 h1 {
     font-size: 24pt;
-    line-height: 30pt;
     font-weight: bold;
     margin: 0;
     margin-bottom: 0pt;
@@ -51,7 +49,6 @@ h1 {
     font-weight: bold;
     width: 50pt;
     font-size: 10pt;
-    line-height: 15pt;
 }
 .verseContent {
     display: inline-block;
@@ -76,7 +73,6 @@ h1 {
 .note {
     font-family: "Open Sans SemiCondensed", sans-serif;
     font-size: 12pt;
-    line-height: 15pt;
     text-align: left;
     float: footnote;
     margin-bottom: 0pt;
@@ -98,5 +94,4 @@ h1 {
 .cv {
     font-weight: bold;
     font-size: 10pt;
-    line-height: 15pt;
 }

--- a/runtime_resources/pdf/para_bible_page_styles.css
+++ b/runtime_resources/pdf/para_bible_page_styles.css
@@ -346,7 +346,6 @@ paras_usfm_sr {
 */
 .marks_chapter_label {
     font-size: 40pt;
-    height: 30pt;
     float: left;
     padding: 0;
     margin: 0 6pt 0 0;

--- a/runtime_resources/pdf/para_bible_page_styles.css
+++ b/runtime_resources/pdf/para_bible_page_styles.css
@@ -22,7 +22,6 @@
 
 body {
     font-size: 12pt;
-    line-height: 14pt;
     font-family: Cardo, serif;
     text-align: justify;
     text-align-last: start;
@@ -57,12 +56,10 @@ h1, h2, h3, h4, .paras_usfm_iot {
     font-size: 0.5em;
     vertical-align: top;
     padding-left: 1pt;
-    line-height: 1;
 }
 
 ::footnote-marker {
     font-weight: normal;
-    line-height: 1;
 }
 
 .glossary_star {
@@ -71,7 +68,6 @@ h1, h2, h3, h4, .paras_usfm_iot {
 
 .bcv_note {
     font-size: 10pt;
-    line-height: 14pt;
     float: footnote;
     font-family: "Open Sans Condensed Light", sans-serif;
 }
@@ -96,12 +92,13 @@ h1, h2, h3, h4, .paras_usfm_iot {
 }
 .paras_usfm_f {
     font-size: 10pt;
-    line-height: 14pt;
     float: footnote;
     font-family: "Open Sans Condensed Light", sans-serif;
 }
+/*
 .paras_usfm_hanging_graft {
 }
+*/
 .paras_usfm_ib {
     min-height: 14pt;
 }
@@ -139,7 +136,6 @@ h1, h2, h3, h4, .paras_usfm_iot {
     font-weight: normal;
     font-style: italic;
     font-size: 24pt;
-    line-height: 28pt;
     text-align: center;
     font-family: "Open Sans Condensed Light", sans-serif;
 }
@@ -147,7 +143,6 @@ h1, h2, h3, h4, .paras_usfm_iot {
     font-weight: normal;
     font-style: italic;
     font-size: 20pt;
-    line-height: 28pt;
     text-align: center;
     font-family: "Open Sans Condensed Light", sans-serif;
 }
@@ -155,7 +150,6 @@ h1, h2, h3, h4, .paras_usfm_iot {
     font-weight: normal;
     font-style: italic;
     font-size: 16pt;
-    line-height: 28pt;
     text-align: center;
     font-family: "Open Sans Condensed Light", sans-serif;
 }
@@ -176,28 +170,24 @@ h1, h2, h3, h4, .paras_usfm_iot {
 .paras_usfm_iot {
     font-weight: bold;
     font-size: 14pt;
-    line-height: 28pt;
     font-family: "Open Sans Condensed Light", sans-serif;
     text-align: left
 }
 .paras_usfm_is {
     font-style: italic;
     font-size: 20pt;
-    line-height: 28pt;
     font-family: "Open Sans Condensed Light", sans-serif;
     break-after: avoid;
 }
 .paras_usfm_is2 {
     font-style: italic;
     font-size: 16pt;
-    line-height: 28pt;
     font-family: "Open Sans Condensed Light", sans-serif;
     break-after: avoid;
 }
 .paras_usfm_is3 {
     font-style: italic;
     font-size: 14pt;
-    line-height: 28pt;
     font-family: "Open Sans Condensed Light", sans-serif;
     break-after: avoid;
 }
@@ -230,13 +220,11 @@ h1, h2, h3, h4, .paras_usfm_iot {
 }
 .paras_usfm_mr {
     font-size: 14pt;
-    line-height: 28pt;
     font-style: italic;
     font-family: Cardo, serif;
 }
 .paras_usfm_ms {
     font-size: 14pt;
-    line-height: 28pt;
     font-weight: bold;
     font-family: Cardo, serif;
 }
@@ -248,7 +236,6 @@ h1, h2, h3, h4, .paras_usfm_iot {
     font-weight: normal;
     font-style: italic;
     font-size: 24pt;
-    line-height: 28pt;
     text-align: center;
     font-family: Cardo, serif;
 }
@@ -256,7 +243,6 @@ h1, h2, h3, h4, .paras_usfm_iot {
     font-weight: normal;
     font-style: italic;
     font-size: 20pt;
-    line-height: 28pt;
     text-align: center;
     font-family: Cardo, serif;
 }
@@ -264,12 +250,13 @@ h1, h2, h3, h4, .paras_usfm_iot {
     font-weight: normal;
     font-style: italic;
     font-size: 16pt;
-    line-height: 28pt;
     text-align: center;
     font-family: Cardo, serif;
 }
+/*
 .paras_usfm_nb {
 }
+*/
 .paras_usfm_p {
     text-indent: 12pt;
     break-inside: auto;
@@ -292,32 +279,26 @@ h1, h2, h3, h4, .paras_usfm_iot {
 .paras_usfm_q {
     padding-left: 12pt;
     text-align: left;
-    line-height: 10pt;
     font-size: 12pt;
-    line-height: 14pt;
 }
 .paras_usfm_q2 {
     padding-left: 24pt;
     text-align: left;
     font-size: 12pt;
-    line-height: 14pt;
 }
 .paras_usfm_q3 {
     padding-left: 36pt;
     text-align: left;
     font-size: 12pt;
-    line-height: 14pt;
 }
 .paras_usfm_q4 {
     padding-left: 48pt;
     text-align: left;
     font-size: 12pt;
-    line-height: 14pt;
 }
 .paras_usfm_qa {
     font-weight: bold;
     font-size: 24pt;
-    line-height: 28pt;
 }
 .paras_usfm_qr {
     text-align: right;
@@ -329,45 +310,43 @@ h1, h2, h3, h4, .paras_usfm_iot {
 .paras_usfm_s {
     font-style: italic;
     font-size: 20pt;
-    line-height: 28pt;
     font-family: Cardo, serif;
     text-align: left;
 }
 .paras_usfm_s2 {
     font-style: italic;
     font-size: 16pt;
-    line-height: 28pt;
     font-family: Cardo, serif;
     text-align: left;
 }
 .paras_usfm_s3 {
     font-style: italic;
     font-size: 14pt;
-    line-height: 28pt;
     font-family: Cardo, serif;
     text-align: left;
 }
 paras_usfm_sr {
     font-size: 16pt;
-    line-height: 28pt;
     font-family: Cardo, serif;
     text-align: left;
 }
+/*
 .paras_usfm_tr {
 }
+*/
 .paras_usfm_x {
     font-size: 10pt;
-    line-height: 14pt;
     float: footnote;
     font-family: Cardo, serif;
 }
 /* marks CSS format : */
+/*
 .marks_default {
 }
+*/
 .marks_chapter_label {
     font-size: 40pt;
     height: 30pt;
-    line-height: 25pt;
     float: left;
     padding: 0;
     margin: 0 6pt 0 0;
@@ -380,13 +359,14 @@ p:has(.marks_chapter_label) {
 .marks_verses_label {
     font-weight: bold;
     font-size: 70%;
-    line-height: 1;
     margin-right: 2pt;
     vertical-align: baseline;
 }
 /* wrappers CSS format : */
+/*
 .wrappers_default {
 }
+*/
 .wrappers_usfm_add {
     font-style: italic;
 }
@@ -400,12 +380,14 @@ p:has(.marks_chapter_label) {
 .wrappers_usfm_bk {
     font-style: italic;
 }
+/*
 .wrappers_chapter {
 }
 .wrappers_usfm_fl {
 }
 .wrappers_usfm_fm {
 }
+*/
 .wrappers_usfm_fq {
     font-style: italic;
 }
@@ -415,8 +397,10 @@ p:has(.marks_chapter_label) {
 .wrappers_usfm_fr {
     font-weight: bold;
 }
+/*
 .wrappers_usfm_ft {
 }
+*/
 .wrappers_usfm_it {
     font-style: italic;
 }
@@ -456,14 +440,18 @@ p:has(.marks_chapter_label) {
 .wrappers_usfm_tl {
     font-style: italic;
 }
+/*
 .wrappers_verses {
 }
 .wrappers_usfm_wj {
 }
 .wrappers_usfm_xk {
 }
+*/
 .wrappers_usfm_xo {
     font-weight: bold;
 }
+/*
 .wrappers_usfm_xt {
 }
+*/


### PR DESCRIPTION
This is a one-size-fits-all solution to avoid Awami row collisions on Print and would resolve this part of [#8](https://github.com/pankosmia/roadmap/issues/8).  It removes all line-height specifications.

As there is no other line-height value set, it is handled by the browser's interpretation of font-size, which generally works out to around 1.2 times the font size.