### PR TITLE
Padauk 6.000 and Awami Nastaliq 3.400 changes

### DIFF
--- a/templates/user_settings.json
+++ b/templates/user_settings.json
@@ -961,72 +961,6 @@
           "value": 0
         }
       ],
-      "Padauk_Book": [
-        {
-          "key": "cv01",
-          "value": 0
-        },
-        {
-          "key": "cv02",
-          "value": 0
-        },
-        {
-          "key": "cv03",
-          "value": 0
-        },
-        {
-          "key": "cv04",
-          "value": 0
-        },
-        {
-          "key": "cv05",
-          "value": 0
-        },
-        {
-          "key": "cv06",
-          "value": 0
-        },
-        {
-          "key": "cv07",
-          "value": 0
-        },
-        {
-          "key": "cv09",
-          "value": 0
-        },
-        {
-          "key": "cv10",
-          "value": 0
-        },
-        {
-          "key": "lldt",
-          "value": 0
-        },
-        {
-          "key": "ulon",
-          "value": 0
-        },
-        {
-          "key": "utal",
-          "value": 0
-        },
-        {
-          "key": "dotc",
-          "value": 1
-        },
-        {
-          "key": "nnya",
-          "value": 0
-        },
-        {
-          "key": "vtta",
-          "value": 0
-        },
-        {
-          "key": "dotr",
-          "value": 0
-        }
-      ],
       "Padauk": [
         {
           "key": "cv01",
@@ -1065,31 +999,133 @@
           "value": 0
         },
         {
-          "key": "lldt",
+          "key": "cv11",
+          "value": 0
+        }
+      ],
+        "Padauk_Medium": [
+        {
+          "key": "cv01",
           "value": 0
         },
         {
-          "key": "ulon",
+          "key": "cv02",
           "value": 0
         },
         {
-          "key": "utal",
+          "key": "cv03",
           "value": 0
         },
         {
-          "key": "dotc",
-          "value": 1
-        },
-        {
-          "key": "nnya",
+          "key": "cv04",
           "value": 0
         },
         {
-          "key": "vtta",
+          "key": "cv05",
           "value": 0
         },
         {
-          "key": "dotr",
+          "key": "cv06",
+          "value": 0
+        },
+        {
+          "key": "cv07",
+          "value": 0
+        },
+        {
+          "key": "cv09",
+          "value": 0
+        },
+        {
+          "key": "cv10",
+          "value": 0
+        },
+        {
+          "key": "cv11",
+          "value": 0
+        }
+      ],
+        "Padauk_Semi_Bold": [
+        {
+          "key": "cv01",
+          "value": 0
+        },
+        {
+          "key": "cv02",
+          "value": 0
+        },
+        {
+          "key": "cv03",
+          "value": 0
+        },
+        {
+          "key": "cv04",
+          "value": 0
+        },
+        {
+          "key": "cv05",
+          "value": 0
+        },
+        {
+          "key": "cv06",
+          "value": 0
+        },
+        {
+          "key": "cv07",
+          "value": 0
+        },
+        {
+          "key": "cv09",
+          "value": 0
+        },
+        {
+          "key": "cv10",
+          "value": 0
+        },
+        {
+          "key": "cv11",
+          "value": 0
+        }
+      ],
+        "Padauk_Extra_Bold": [
+        {
+          "key": "cv01",
+          "value": 0
+        },
+        {
+          "key": "cv02",
+          "value": 0
+        },
+        {
+          "key": "cv03",
+          "value": 0
+        },
+        {
+          "key": "cv04",
+          "value": 0
+        },
+        {
+          "key": "cv05",
+          "value": 0
+        },
+        {
+          "key": "cv06",
+          "value": 0
+        },
+        {
+          "key": "cv07",
+          "value": 0
+        },
+        {
+          "key": "cv09",
+          "value": 0
+        },
+        {
+          "key": "cv10",
+          "value": 0
+        },
+        {
+          "key": "cv11",
           "value": 0
         }
       ]

--- a/templates/user_settings.json
+++ b/templates/user_settings.json
@@ -261,6 +261,10 @@
           "value": 0
         },
         {
+          "key": "hihm",
+          "value": 0
+        },
+        {
           "key": "wdsp",
           "value": 2
         },
@@ -300,6 +304,10 @@
         },
         {
           "key": "hamz",
+          "value": 0
+        },
+        {
+          "key": "hihm",
           "value": 0
         },
         {
@@ -345,6 +353,10 @@
           "value": 0
         },
         {
+          "key": "hihm",
+          "value": 0
+        },
+        {
           "key": "wdsp",
           "value": 2
         },
@@ -384,6 +396,10 @@
         },
         {
           "key": "hamz",
+          "value": 0
+        },
+        {
+          "key": "hihm",
           "value": 0
         },
         {


### PR DESCRIPTION
# 1 of 3 Integrated PR's
This PR is to be reviewed and merged in conjunction with its corresponding webfonts-core and core-client-settings PR's.

## Summary of changes:
- updated font-feature-settings for Padauk, as v6.000 eliminates previously graphite-only settings
- removed font-feature-settings for Padauk Book, as v6.000 remove that in favor of the next items added
- added font-feature-settings for Padauk_Medium, Padauk_Semi_Bold, and Padauk_Extra_Bold
- added one font-feature-setting for all Awami Nastaliq fonts

## Caution and Consideration:
- this PR will require users to delete user_settings.json on install, which under current behavior also requires deletion of `~/pankomia/[short_app_name]` and all of its contents, otherwise everything does not get put back
  - our script that deletes on install currently only deletes `i18n.json`, `webfonts` and `temp`. 